### PR TITLE
Updated InboxStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SnooStorm
 ===
 
-Recently added InboxStream that gets unread messages
+Recently added InboxStream that gets messages from a user's Inbox
 
 
 An event based wrapper around snoowrap
@@ -38,5 +38,14 @@ submissionStream.on("submission", function(post) {
 setTimeout(function() {
     submissionStream.emit("stop"); // Stop recieving new events
 }, 1000);
+
+var inboxStream = client.InboxStream({
+  "filter": "unread",       // inbox, unread (default), messages, comments, selfreply, or mentions
+  "pollTime": 15000
+});
+
+inboxStream.on("PrivateMessage", function(pm) {
+  console.log(`New PM from ${pm.author.name}`);
+});
 
 ```

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ const SnooStorm = (function() {
     options.subreddit = options.subreddit || "all";
     options.results = options.results  || 5;
     options.pollTime = options.pollTime || 2000
+    options.filter = options.filter || "unread"; // inbox, unread, messages, comments, selfreply, or mentions 
     return options
   }
 
@@ -110,7 +111,9 @@ const SnooStorm = (function() {
       let client = this.client
 
       let id = setInterval(function() {
-        client.getUnreadMessages().then(function(listing) {
+        client.getInbox({
+          filter: options.filter,
+        }).then(function(listing) {
           removeDuplicates(lastBatch, listing, start).forEach(function(post) {
           event.emit("PrivateMessage", post);
         })

--- a/main.js
+++ b/main.js
@@ -110,10 +110,12 @@ const SnooStorm = (function() {
       let client = this.client
 
       let id = setInterval(function() {
-        client.getUnreadMessages().forEach(function(post) {
+        client.getUnreadMessages().then(function(listing) {
+          removeDuplicates(lastBatch, listing, start).forEach(function(post) {
           event.emit("PrivateMessage", post);
         })
-        .catch(function(error) {
+        lastBatch = listing
+        }).catch(function(error) {
             event.emit("error", error);
         });
       }, options.pollTime);
@@ -121,8 +123,8 @@ const SnooStorm = (function() {
       event.on("stop", function() {
         clearInterval(id)
       })
+      
       return event
-
     }
 
   };


### PR DESCRIPTION
The following updates were added/implemented:
- `InboxStream` uses `getInbox()` instead of `getUnreadMessages()`
- `InboxStream` uses a new option `options.filter`
- Set the default filter to "unread" to maintain original functionality of `InboxStream`
- Added example usage of `InboxStream` to the README