### PR TITLE
snyk isn't needed to run, so move it into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@types/node": "^11.9.5",
     "@types/snoowrap": "^1.15.3",
-    "snoowrap": "^1.19.0",
+    "snoowrap": "^1.19.0"
+  },
+  "devDependencies": {
     "snyk": "^1.189.0"
   },
   "homepage": "https://github.com/MayorMonty/Snoostorm#readme",


### PR DESCRIPTION
Snyk may be useful when you're developing the library, but you don't need it when you're just using it. This moves it into devDependencies so it only gets installed if you're developing the library.