### PR TITLE
Fix mentions in InboxStream, add limit parameter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,11 +45,13 @@ export class InboxStream extends Poll<
         | "messages"
         | "comments"
         | "selfreply"
-        | "mentions ";
+        | "mentions";
       pollTime: number;
+      limit: number;
     } = {
       filter: "inbox",
-      pollTime: 2000
+      pollTime: 2000,
+      limit: 5
     }
   ) {
     super({


### PR DESCRIPTION
* Removed the trailing space in InboxStream's `mentions`
* Added the `limit` parameter to InboxStream
