### PR TITLE
Resolve Performance Memory Issue

### DIFF
--- a/src/util/Poll.ts
+++ b/src/util/Poll.ts
@@ -41,8 +41,10 @@ export default class Poll<T extends object> extends EventEmitter {
       const batch = await get();
 
       const newItems: T[] = [];
+      const seen: Set<T[keyof T]> = new Set();
       for (const item of batch) {
         const id = item[identifier];
+        seen.add(id);
         if (this.processed.has(id)) continue;
 
         // Emit for new items and add it to the list
@@ -51,6 +53,7 @@ export default class Poll<T extends object> extends EventEmitter {
         this.emit("item", item);
       }
 
+      this.processed = new Set(seen);
       // Emit the new listing of all new items
       this.emit("listing", newItems);
     }, frequency);


### PR DESCRIPTION
Over time on really long watches, the `processed` variable could become extremely large. Since we only care about what we have seen and no longer care about what can no longer be seen, based on the limit - We can solve this by overwriting the processed with what has come back in the batch.